### PR TITLE
New feature: Exclude steam group members

### DIFF
--- a/scripting/veterans.sp
+++ b/scripting/veterans.sp
@@ -12,7 +12,6 @@ new String:ExcludeFile[PLATFORM_MAX_PATH];
 new bool:isBlocked = false;
 
 new Handle:cvar_url;
-new Handle:cvar_apiKey;
 new Handle:cvar_enable;
 new Handle:cvar_minPlaytime;
 new Handle:cvar_minPlaytimeExcludingLast2Weeks;
@@ -50,12 +49,6 @@ public OnPluginStart()
 		"sm_veterans_url",
 		"http://falahati.net/steamapi/queryPlaytime.php",
 		"Address of the PHP file responsible for getting user played time.",
-		FCVAR_PROTECTED
-	);
-	cvar_apiKey = CreateConVar(
-		"sm_veterans_apikey",
-		"1B95D6DBDBE6F4E07589FD5671922E23",
-		"Steam Web API key (compulsory, you can require a key at https://steamcommunity.com/dev/apikey)",
 		FCVAR_PROTECTED
 	);
 	cvar_enable = CreateConVar(
@@ -387,8 +380,6 @@ bool:IsWhitelisted(const String:steamId[])
 // --------------------------------- WEB COMMUNICATION ---------------------------------
 RequestUserInfo(client, const String:steamId[])
 {
-	decl String:apiKey[40];
-	GetConVarString(cvar_apiKey, apiKey, sizeof apiKey);
 	decl String:gameId[16];
 	GetConVarString(cvar_gameId, gameId, sizeof gameId);
 	
@@ -397,8 +388,7 @@ RequestUserInfo(client, const String:steamId[])
 	new Handle:hRequest = SteamWorks_CreateHTTPRequest(EHTTPMethod:k_EHTTPMethodGET, url);
 	
 	SteamWorks_SetHTTPRequestNetworkActivityTimeout(hRequest, GetConVarInt(cvar_connectionTimeout));
-	
-	SteamWorks_SetHTTPRequestGetOrPostParameter(hRequest, "key", apiKey);
+
 	SteamWorks_SetHTTPRequestGetOrPostParameter(hRequest, "gameId", gameId);
 	SteamWorks_SetHTTPRequestGetOrPostParameter(hRequest, "steamId", steamId);
 	if (GetConVarBool(cvar_excludeGroupMember))

--- a/scripting/veterans.sp
+++ b/scripting/veterans.sp
@@ -128,12 +128,13 @@ public OnPluginStart()
 		FCVAR_NONE, true, 0.0, true, 1.0
 	);
 
-	RegAdminCmd("sm_veterans_exclude", RemoveFromWhitelist, ADMFLAG_GENERIC, "Exludes a user from veterans plugin", "", 0);
-	RegAdminCmd("sm_veterans_include", AddToWhitelist, ADMFLAG_GENERIC, "Includes an already excluded user from veterans plugin", "", 0);
-	RegAdminCmd("sm_veterans_clear", ClearPlaytimeCache, ADMFLAG_GENERIC, "Includes an already excluded user from veterans plugin", "", 0);
+	RegAdminCmd("sm_veterans_exclude", AddToWhitelist, ADMFLAG_GENERIC, "Exludes a user from veterans plugin", "", 0);
+	RegAdminCmd("sm_veterans_include", RemoveFromWhitelist, ADMFLAG_GENERIC, "Includes an already excluded user from veterans plugin", "", 0);
+	RegAdminCmd("sm_veterans_clear", ClearPlaytimeCache, ADMFLAG_GENERIC, "Clear cache", "", 0);
 
 	AutoExecConfig(true, "veterans");
-	BuildPath(Path_SM, CacheFile, sizeof(CacheFile), "data/veterans_cache.txt");
+	new iPort = GetConVarInt(FindConVar("hostport"));
+	BuildPath(Path_SM, CacheFile, sizeof(CacheFile), "data/veterans_cache_%d.txt", iPort);
 	BuildPath(Path_SM, ExcludeFile, sizeof(ExcludeFile), "data/veterans_exclude.txt");
 }
 
@@ -262,7 +263,7 @@ bool:HasEnoughPlaytime(int totalTime, int last2WeeksTime)
 }
 
 // --------------------------------- PLAYER EXCEPTIONS ---------------------------------
-public Action:RemoveFromWhitelist(int client, int args)
+public Action:AddToWhitelist(int client, int args)
 {
 	if (args < 1) {
 		ReplyToCommand(client, "Usage: !sm_veterans_exclude <steamid1> <steamid2> ...");
@@ -299,7 +300,7 @@ public Action:RemoveFromWhitelist(int client, int args)
 	return Plugin_Handled;
 } 
 
-public Action:AddToWhitelist(int client, int args)
+public Action:RemoveFromWhitelist(int client, int args)
 {
 	if (args < 1) {
 		ReplyToCommand(client, "Usage: !sm_veterans_include <steamid1> <steamid2> ...");
@@ -474,7 +475,7 @@ CleanupPlaytimeCache(bool:clearAll)
 		}
 	} while (KvGotoNextKey(kv));
 	KvRewind(kv);
-	KeyValuesToFile(kv, "VeteranPlayerCache.txt");
+	KeyValuesToFile(kv, CacheFile);
 	CloseHandle(kv);
 }
 

--- a/scripting/veterans.sp
+++ b/scripting/veterans.sp
@@ -12,6 +12,7 @@ new String:ExcludeFile[PLATFORM_MAX_PATH];
 new bool:isBlocked = false;
 
 new Handle:cvar_url;
+new Handle:cvar_apiKey;
 new Handle:cvar_enable;
 new Handle:cvar_minPlaytime;
 new Handle:cvar_minPlaytimeExcludingLast2Weeks;
@@ -22,6 +23,8 @@ new Handle:cvar_kickWhenPrivate;
 new Handle:cvar_excludeReservedSlots;
 new Handle:cvar_excludePrivileged;
 new Handle:cvar_excludePrimes;
+new Handle:cvar_excludeGroupMember;
+new Handle:cvar_groupID;
 new Handle:cvar_kickF2P;
 new Handle:cvar_banTime;
 new Handle:cvar_gameId;
@@ -47,6 +50,12 @@ public OnPluginStart()
 		"sm_veterans_url",
 		"http://falahati.net/steamapi/queryPlaytime.php",
 		"Address of the PHP file responsible for getting user played time.",
+		FCVAR_PROTECTED
+	);
+	cvar_apiKey = CreateConVar(
+		"sm_veterans_apikey",
+		"1B95D6DBDBE6F4E07589FD5671922E23",
+		"Steam Web API key (compulsory, you can require a key at https://steamcommunity.com/dev/apikey)",
 		FCVAR_PROTECTED
 	);
 	cvar_enable = CreateConVar(
@@ -84,6 +93,18 @@ public OnPluginStart()
 		"0",
 		"Should we exclude privileged players from punishment?",
 		FCVAR_NONE, true, 0.0, true, 1.0
+	);
+	cvar_excludeGroupMember = CreateConVar(
+		"sm_veterans_excludegroupmember",
+		"0",
+		"Should we exclude players that are members of our Steam group?",
+		FCVAR_NONE, true, 0.0, true, 1.0
+	);
+	cvar_groupID = CreateConVar(
+		"sm_veterans_groupid",
+		"xxxxxxxx",
+		"Steam Group ID (same as your sv_steamgroup)",
+		FCVAR_NONE
 	);
 	cvar_connectionTimeout = CreateConVar(
 		"sm_veterans_timeout",
@@ -217,11 +238,11 @@ public OnClientAuthorized(client, const String:steamId[])
 
 	}
 
-	new totalTime, last2WeeksTime;
-	if (QueryCachedPlayTime(SteamIdToInt(steamId), totalTime, last2WeeksTime))
+	new totalTime, last2WeeksTime, isGroupMember;
+	if (QueryCachedData(SteamIdToInt(steamId), totalTime, last2WeeksTime, isGroupMember))
 	{
 		PrintToServer("VeteransOnly: New client, playtime loaded from cache for SteamId %s", steamId);
-		CheckUserPlaytime(client, totalTime, last2WeeksTime);
+		CheckIfUserQualified(client, totalTime, last2WeeksTime, isGroupMember);
 	} else {
 		PrintToServer("VeteransOnly: New client, requesting playtime for SteamId %s", steamId);
 		RequestUserInfo(client, steamId);
@@ -229,8 +250,14 @@ public OnClientAuthorized(client, const String:steamId[])
 }
 
 // --------------------------------- PLAYER TIME DECISION ---------------------------------
-CheckUserPlaytime(client, totalTime, last2WeeksTime)
+CheckIfUserQualified(client, totalTime, last2WeeksTime, isGroupMember)
 {
+	if (GetConVarBool(cvar_excludeGroupMember) && isGroupMember)
+	{
+		PrintToServer("VeteransOnly: Excluded for being a group member");
+		return;
+	}
+
 	if (HasEnoughPlaytime(totalTime, last2WeeksTime))
 	{
 		return;
@@ -360,12 +387,10 @@ bool:IsWhitelisted(const String:steamId[])
 // --------------------------------- WEB COMMUNICATION ---------------------------------
 RequestUserInfo(client, const String:steamId[])
 {
+	decl String:apiKey[40];
+	GetConVarString(cvar_apiKey, apiKey, sizeof apiKey);
 	decl String:gameId[16];
-	IntToString(GetConVarInt(cvar_gameId), gameId, sizeof gameId);
-	decl String:maxTotal[16];
-	IntToString(GetConVarInt(cvar_minPlaytime), maxTotal, sizeof maxTotal);
-	decl String:maxTotalNo2Weeks[16];
-	IntToString(GetConVarInt(cvar_minPlaytimeExcludingLast2Weeks), maxTotalNo2Weeks, sizeof maxTotalNo2Weeks);
+	GetConVarString(cvar_gameId, gameId, sizeof gameId);
 	
 	decl String:url[256];
 	GetConVarString(cvar_url, url, sizeof url);
@@ -373,10 +398,15 @@ RequestUserInfo(client, const String:steamId[])
 	
 	SteamWorks_SetHTTPRequestNetworkActivityTimeout(hRequest, GetConVarInt(cvar_connectionTimeout));
 	
+	SteamWorks_SetHTTPRequestGetOrPostParameter(hRequest, "key", apiKey);
 	SteamWorks_SetHTTPRequestGetOrPostParameter(hRequest, "gameId", gameId);
 	SteamWorks_SetHTTPRequestGetOrPostParameter(hRequest, "steamId", steamId);
-	SteamWorks_SetHTTPRequestGetOrPostParameter(hRequest, "maxTotal", maxTotal);
-	SteamWorks_SetHTTPRequestGetOrPostParameter(hRequest, "maxTotalNo2Weeks", maxTotalNo2Weeks);
+	if (GetConVarBool(cvar_excludeGroupMember))
+	{
+		decl String:groupId[16];
+		GetConVarString(cvar_groupID, groupId, sizeof groupId);
+		SteamWorks_SetHTTPRequestGetOrPostParameter(hRequest, "groupId", groupId);
+	}
 
 	SteamWorks_SetHTTPCallbacks(hRequest, UserInfoRetrieved);
 	SteamWorks_SetHTTPRequestContextValue(hRequest, SteamIdToInt(steamId), GetClientUserId(client));
@@ -411,14 +441,14 @@ public UserInfoRetrieved(Handle:HTTPRequest, bool:bFailure, bool:bRequestSuccess
 		return;
 	}
 	
-	new totalTime, last2WeeksTime;
+	new totalTime, last2WeeksTime, isGroupMember;
 
 	new iBodySize;
 	if (SteamWorks_GetHTTPResponseBodySize(HTTPRequest, iBodySize))
 	{
 		decl String:sBody[iBodySize + 1];
 		SteamWorks_GetHTTPResponseBodyData(HTTPRequest, sBody, iBodySize);
-		if (iBodySize <= 4 || StrEqual(sBody, "||"))
+		if (iBodySize <= 6 || StrContains(sBody, "|0|0|0|") != -1)
 		{
 			if (GetConVarBool(cvar_kickWhenPrivate))
 			{
@@ -428,12 +458,13 @@ public UserInfoRetrieved(Handle:HTTPRequest, bool:bFailure, bool:bRequestSuccess
 			}
 			return;
 		} else if (StrContains(sBody, "|") >= 0) {
-			decl String:times[4][10];
+			decl String:times[5][10];
 			ExplodeString(sBody, "|", times, sizeof times, sizeof times[]);
 			totalTime = StringToInt(times[1]);
 			last2WeeksTime = StringToInt(times[2]);
-			CachePlaytime(steamIntId, totalTime, last2WeeksTime);
-			CheckUserPlaytime(client, totalTime, last2WeeksTime);
+			isGroupMember = StringToInt(times[3]);
+			CacheUserData(steamIntId, totalTime, last2WeeksTime, isGroupMember);
+			CheckIfUserQualified(client, totalTime, last2WeeksTime, isGroupMember);
 			return;
 		}
 	}
@@ -479,7 +510,7 @@ CleanupPlaytimeCache(bool:clearAll)
 	CloseHandle(kv);
 }
 
-CachePlaytime(int steamIntId, int totalTime, int last2WeeksTime)
+CacheUserData(int steamIntId, int totalTime, int last2WeeksTime, int isGroupMember)
 {
 	decl String:steamId[32];
 	IntToString(steamIntId, steamId, sizeof steamId);
@@ -490,12 +521,13 @@ CachePlaytime(int steamIntId, int totalTime, int last2WeeksTime)
 	KvSetNum(kv, "LastUpdate", GetTime());
 	KvSetNum(kv, "TotalTime", totalTime);
 	KvSetNum(kv, "Last2WeeksTime", last2WeeksTime);
+	KvSetNum(kv, "isGroupMember", isGroupMember);
 	KvRewind(kv);
 	KeyValuesToFile(kv, CacheFile);
 	CloseHandle(kv);
 }
 
-bool:QueryCachedPlayTime(int steamIntId, int &totalTime, int &last2WeeksTime)
+bool:QueryCachedData(int steamIntId, int &totalTime, int &last2WeeksTime, int &isGroupMember)
 {
 	decl String:steamId[32];
 	IntToString(steamIntId, steamId, sizeof steamId);
@@ -511,6 +543,7 @@ bool:QueryCachedPlayTime(int steamIntId, int &totalTime, int &last2WeeksTime)
 	}
 	totalTime =			KvGetNum(kv, "TotalTime");
 	last2WeeksTime =	KvGetNum(kv, "Last2WeeksTime");
+	isGroupMember =		KvGetNum(kv, "isGroupMember");
 	CloseHandle(kv);
 	return true;
 }

--- a/scripting/veterans.sp
+++ b/scripting/veterans.sp
@@ -172,7 +172,7 @@ public OnClientAuthorized(client, const String:steamId[])
 		return;
 	}
 
-	new adminId = GetUserAdmin(client);
+	AdminId adminId = GetUserAdmin(client);
 
 	if (adminId != INVALID_ADMIN_ID) {
 		// Exclude privileged
@@ -181,12 +181,12 @@ public OnClientAuthorized(client, const String:steamId[])
 		}
 		
 		// Exclude reserved slots
-		if (GetConVarBool(cvar_excludeReservedSlots) && GetAdminFlag(adminId, ADMFLAG_RESERVATION)) {
+		if (GetConVarBool(cvar_excludeReservedSlots) && GetAdminFlag(adminId, Admin_Reservation)) {
 			return;
 		}
 
 		// Exclude admins
-		if (GetAdminFlag(adminId, ADMFLAG_GENERIC) || GetAdminFlag(adminId, ADMFLAG_ROOT)) {
+		if (GetAdminFlag(adminId, Admin_Generic) || GetAdminFlag(adminId, Admin_Root)) {
 			return;
 		}
 	}

--- a/web/queryPlaytime.php
+++ b/web/queryPlaytime.php
@@ -4,20 +4,22 @@ ini_set("display_errors", 0);
 ini_set("log_errors", 1);
 ini_set("error_log", "php-error.log");
 
+// you can acquire a key at https://steamcommunity.com/dev/apikey
+define('APIKEY', "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");  // replace with your key
+
 function Handle()
 {
-	if (!isset($_GET['key']) || !isset($_GET['steamId']) || !isset($_GET['gameId']))
+	if (!defined('APIKEY') || !isset($_GET['steamId']) || !isset($_GET['gameId']))
 	{
 		header('X-PHP-Response-Code: 406', true, 406);
 		goto returnFinally;
 	}
 
-	$key = trim(strtoupper($_GET['key']));
 	$steamId = trim(strtoupper($_GET['steamId']));
 	$gameId = intval($_GET['gameId']);
 	$communityId = GetFriendId($steamId);
 
-	if (!$key || !$gameId || !$communityId)
+	if (!$gameId || !$communityId)
 	{
 		header('X-PHP-Response-Code: 406', true, 406);
 		goto returnFinally;
@@ -37,7 +39,7 @@ function Handle()
 	// encoded json: {"steamid":xxxxxxxxxxxxxxxxx,"appids_filter":[xxx]}
 	$playtime_query =
 		"http://api.steampowered.com/IPlayerService/GetOwnedGames/v1/?key="
-		. $key . "&format=json&input_json=%7B%22steamid%22%3A"
+		. APIKEY . "&format=json&input_json=%7B%22steamid%22%3A"
 		. $communityId . "%2C%22appids_filter%22%3A%5B"
 		. $gameId . "%5D%7D";
 
@@ -54,7 +56,7 @@ function Handle()
 
 		$groups_query =
 			"http://api.steampowered.com/ISteamUser/GetUserGroupList/v1/?key="
-			. $key . "&format=json&steamid="
+			. APIKEY . "&format=json&steamid="
 			. $communityId;
 
 		$groups_json = @file_get_contents($groups_query);


### PR DESCRIPTION
New exclude condition: if player is member of the steam group (new cvars: **sm_veterans_excludegroupmember**, **sm_veterans_groupid**).
Use the new Steam Web API to optimize the query speed (new cvar: **sm_veterans_apikey**)

Example query:
1. [Playtime](https://api.steampowered.com/IPlayerService/GetOwnedGames/v1/?key=1B95D6DBDBE6F4E07589FD5671922E23&format=json&input_json=%7B%22steamid%22%3A76561198984815963%2C%22appids_filter%22%3A%5B550%5D%7D), this uses a filter to select our desired game stats, rather than query all data. The filter here is a json data `{"steamid":76561198984815963,"appids_filter":[550]}`, using [urlencoder](https://www.urlencoder.org/) to encode.
2. [GetUserGroupList](https://api.steampowered.com/ISteamUser/GetUserGroupList/v1/?key=1B95D6DBDBE6F4E07589FD5671922E23&format=json&steamid=76561198984815963), this returns all groups that the user is in. We choose this way rather than querying the member list of the specific group, which is a lot slower(if the group has many members).